### PR TITLE
Pass domain env var to nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ make down
 - All container images are built from Debian 12 base.
 - Nginx is the sole HTTPS entrypoint, serving via FastCGI to PHP-FPM.
 - Docker secrets are used for database credentials and TLS certificates.
+- `docker-compose` passes `DOMAIN=${LOGIN}.42.fr` to the nginx container so the
+  `server_name` is configured dynamically.
 
 ---
 

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.8'
 services:
   nginx:
     build: ./requirements/nginx
+    environment:
+      - DOMAIN=${LOGIN}.42.fr
     ports:
       - "443:443"
     volumes:

--- a/srcs/requirements/nginx/conf/nginx.conf
+++ b/srcs/requirements/nginx/conf/nginx.conf
@@ -1,4 +1,5 @@
 worker_processes 1;
+env DOMAIN;
 events { worker_connections 1024; }
 
 http {
@@ -12,7 +13,7 @@ http {
 
   server {
     listen 443 ssl;
-    server_name amema.42.fr;
+    server_name $DOMAIN;
 
     ssl_certificate     /etc/nginx/certs/server.crt;
     ssl_certificate_key /etc/nginx/certs/server.key;


### PR DESCRIPTION
## Summary
- allow nginx server_name to pull from DOMAIN env var
- set DOMAIN=${LOGIN}.42.fr in docker-compose
- document domain configuration in README

## Testing
- `docker-compose -f srcs/docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c8dcb1788832a90768b9c4e657399